### PR TITLE
Readme's example fix

### DIFF
--- a/README.patch
+++ b/README.patch
@@ -1,0 +1,11 @@
+--- README.md		Thu Nov 16 19:38:46 2017
++++ README.md.new	Wed Nov 22 05:08:37 2017
+@@ -270,7 +270,7 @@
+    But, if you really want this, you can run a separate thread which will just periodically call ltalloc_squeeze(0). Here is one-liner for C++11:
+ 
+ ```c++
+-std::thread([] {for (;;ltalloc_squeeze(0)) std::this_thread::sleep_for(std::chrono::seconds(3));}).detach();
++std::thread([] { for (;;ltsqueeze(0)) std::this_thread::sleep_for(std::chrono::seconds(3)); }).detach();
+ ```
+ 
+ 1. Why there are no any memory statistics provided by the allocator?


### PR DESCRIPTION
This example contains error. Current library version does not contains function ltalloc_squeeze, it names ltsqueeze