### PR TITLE
Patch for support ltalloc on SPARC architecture

### DIFF
--- a/ltalloc_sparc.patch
+++ b/ltalloc_sparc.patch
@@ -1,0 +1,14 @@
+--- ltalloc.cc	Thu Nov 16 19:38:46 2017
++++ ltalloc.cc	Thu Nov 23 04:21:30 2017
+@@ -79,7 +79,11 @@
+ #define NOINLINE __attribute__((noinline))
+ #define CAS_LOCK(lock) __sync_lock_test_and_set(lock, 1)
+ #define SPINLOCK_RELEASE(lock) __sync_lock_release(lock)
++#ifdef __sparc__
++#define PAUSE asm volatile("rd    %%ccr, %%g0\n\t" ::: "memory")
++#else
+ #define PAUSE __asm__ __volatile__("pause" ::: "memory")
++#endif
+ #define BSR(r, v) r = CODE3264(__builtin_clz(v) ^ 31, __builtin_clzll(v) ^ 63)//x ^ 31 = 31 - x, but gcc does not optimize 31 - __builtin_clz(x) to bsr(x), but generates 31 - (bsr(x) ^ 31)
+ 
+ #elif _MSC_VER


### PR DESCRIPTION
Hi, Mario.
I've be forced to write this patch due to I require to use library on SPARC processors, and PAUSE definition is not compatible (syntaxically) with SPARC assembler. I've tried to write patch most compatible for most SPARC processors. It was tested with GCC 5.2 on SPARCv9 and seems ok. Library usable.