### PR TITLE
Bugfixed ltalloc.h

### DIFF
--- a/ltalloc.h.new
+++ b/ltalloc.h.new
@@ -1,0 +1,14 @@
+#include <stdlib.h>  /*a more portable size_t definition than stddef.h itself*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+void*  ltmalloc(size_t);
+void   ltfree(void*);
+void*  ltrealloc(void*, size_t);
+void*  ltcalloc(size_t, size_t);
+void*  ltmemalign(size_t, size_t);
+void   ltsqueeze(size_t); /*return memory to system (see README.md)*/
+size_t ltmsize(void*);
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Was wrong declaration void   ltsqueeze(size_t); should be only with argument type, not with name ;)

With this header (and corrected ltalloc.cc above) now library can be used standalone (by including directly in sources), as linked object library, and as external lib.